### PR TITLE
Fix signed shift warning for nlmacros BITMASK

### DIFF
--- a/include/nlmacros.h
+++ b/include/nlmacros.h
@@ -164,7 +164,7 @@
 
 // Each parameter evaluated once
 #ifndef BITMASK
-#define BITMASK(b, s)                           ((~(~0 << (b))) << (s))
+#define BITMASK(b, s)                           ((~(~0U << (b))) << (s))
 #endif
 #ifndef NL_BIT
 #define NL_BIT(s)                               BITMASK(1, s)


### PR DESCRIPTION
Clang gives a warning for the BITMASK macro:

    Shifting a negative signed value is undefined [-Wshift-negative-value]

The value in question is the literal "~0", which defaults to being a
signed integer. It is clearly intended to be used as an unsigned
integer, though, but happens to have the correct behavior because the
compilers/hardware don't do anything too crazy with an overflowing
left-shift in the signed case, despite it being undefined behavior.